### PR TITLE
Divide shared component at survey list component

### DIFF
--- a/components/shared/badge/DotBadge.tsx
+++ b/components/shared/badge/DotBadge.tsx
@@ -1,0 +1,40 @@
+import styled from "styled-components";
+import { PROGRESS_STATUS } from "../../../constants/survey_list";
+import { COLOR } from "../../../constants/themes";
+
+interface Props {
+  status: string;
+}
+
+export default function DotBadge({ status }: Props) {
+  return <Badge status={status}>{status}</Badge>;
+}
+
+const Badge = styled.div<Props>`
+  flex: 1;
+  position: relative;
+  max-width: 160px;
+  height: 40px;
+  padding: 0 20px 0 40px;
+  border: 1px solid #ccc;
+  border-radius: 20px 20px 0 20px;
+  margin-left: 20px;
+  line-height: 40px;
+  font-size: 14px;
+  font-weight: 700;
+  &:before {
+    content: "";
+    display: inline-block;
+    position: absolute;
+    left: 20px;
+    top: 15px;
+    width: 10px;
+    height: 10px;
+    border-radius: 50%;
+    background: ${({ status }) => {
+      if (status === PROGRESS_STATUS.DONE) return "#ccc";
+      if (status === PROGRESS_STATUS.NOT_STARTED) return COLOR.BEIGE;
+      return COLOR.DACK_ORANGE;
+    }};
+  }
+`;

--- a/components/shared/icon/ListIcon.tsx
+++ b/components/shared/icon/ListIcon.tsx
@@ -1,0 +1,35 @@
+import styled from "styled-components";
+
+import { COLOR } from "../../../constants/themes";
+
+interface Props {
+  status: string;
+}
+
+export default function ListIcon({ status }: Props) {
+  return <Icon status={status}></Icon>;
+}
+
+const Icon = styled.i<Props>`
+  display: inline-block;
+  position: relative;
+  width: 40px;
+  height: 40px;
+  margin-right: 20px;
+  background: url("icon_list.png") no-repeat left center / 100%;
+  &:after {
+    content: "";
+    position: absolute;
+    right: 3px;
+    bottom: 4px;
+    display: inline-block;
+    width: 7px;
+    height: 7px;
+    background: ${({ status }) => {
+      if (status === "Done") return "#ccc";
+      if (status === "Not Started") return COLOR.BEIGE;
+      return COLOR.DACK_ORANGE;
+    }};
+    border-radius: 50%;
+  }
+`;

--- a/components/shared/progress/BarProgress.tsx
+++ b/components/shared/progress/BarProgress.tsx
@@ -1,0 +1,33 @@
+import styled from "styled-components";
+import { COLOR } from "../../../constants/themes";
+
+interface Props {
+  number: number;
+}
+
+export default function BarProgress({ number }: Props) {
+  return <Progress number={number}>{number}</Progress>;
+}
+
+const Progress = styled.div<Props>`
+  flex: 2;
+  position: relative;
+  width: 250px;
+  height: 10px;
+  margin-right: 40px;
+  background: #eee;
+  font-size: 0;
+  border-radius: 10px;
+  overflow: hidden;
+  &:after {
+    content: "";
+    display: block;
+    position: absolute;
+    left: 0;
+    top: 0;
+    width: ${({ number }) => `${number}%`};
+    height: 10px;
+    background: ${({ number }) =>
+      number === 100 ? "#ccc" : COLOR.DACK_ORANGE};
+  }
+`;

--- a/components/shared/title/TitieBox.tsx
+++ b/components/shared/title/TitieBox.tsx
@@ -1,0 +1,58 @@
+import styled from "styled-components";
+
+import { COLOR } from "../../../constants/themes";
+
+interface ButtonInfo {
+  text: string;
+  onClick(): void;
+}
+
+interface Props {
+  title: string;
+  buttonInfo: Array<ButtonInfo>;
+}
+
+export default function TitleBox({ title, buttonInfo }: Props) {
+  return (
+    <TitleArea>
+      <Title>{title}</Title>
+      <ButtonArea>
+        {buttonInfo.map((item) => (
+          <Button onClick={item.onClick} key={item.text}>
+            {item.text}
+          </Button>
+        ))}
+      </ButtonArea>
+    </TitleArea>
+  );
+}
+
+const TitleArea = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  position: sticky;
+  top: 14px;
+  z-index: 20;
+`;
+
+const Title = styled.div`
+  font-size: 30px;
+  font-weight: 700;
+`;
+
+const Button = styled.button`
+  width: 150px;
+  height: 50px;
+  border-radius: 25px;
+  background: ${COLOR.CREAM_ORANGE};
+  font-size: 16px;
+  color: #fff;
+  font-weight: 700;
+`;
+
+const ButtonArea = styled.div`
+  ${Button} {
+    margin-left: 20px;
+  }
+`;

--- a/constants/survey_list/index.ts
+++ b/constants/survey_list/index.ts
@@ -1,0 +1,5 @@
+export const PROGRESS_STATUS = {
+  DONE: "Done",
+  NOT_STARTED: "Not Started",
+  IN_PROGRESS: "In Progress",
+};

--- a/pages/survey_list.tsx
+++ b/pages/survey_list.tsx
@@ -1,6 +1,12 @@
 import Link from "next/link";
+import { useRouter } from "next/router";
 import styled from "styled-components";
-import { COLOR } from "../constants/themes";
+
+import DotBadge from "../components/shared/badge/DotBadge";
+import ListIcon from "../components/shared/icon/ListIcon";
+import BarProgress from "../components/shared/progress/BarProgress";
+import TitleBox from "../components/shared/title/TitieBox";
+import { progressText } from "../uttils/survey_list";
 
 const results = [
   {
@@ -35,35 +41,31 @@ const results = [
   },
 ];
 export default function SurveyList() {
-  const progressText = (status: number) => {
-    if (status === 100) return "Done";
-    if (status === 0) return "Not Started";
-    return "In Progress";
+  const router = useRouter();
+
+  const handleClick = () => {
+    router.push(`/login`);
   };
 
   return (
     <Content>
-      <TitleBox>
-        <Title>나의 설문 목록</Title>
-        <Button>설문추가</Button>
-      </TitleBox>
+      <TitleBox
+        title="나의 설문 목록"
+        buttonInfo={[{ text: "설문추가", onClick: handleClick }]}
+      />
       <List>
         {results &&
           results.map((item) => (
             <ListItem key={item.id}>
               <Link href={``}>
                 <Item>
-                  <ListIcon status={progressText(item.progress)}></ListIcon>
+                  <ListIcon status={progressText(item.progress)} />
                   <TextBox>
                     <h3>{item.title}</h3>
                     <p>{item.desc}</p>
                   </TextBox>
-                  <Progress number={item.progress}>
-                    progress{item.progress}
-                  </Progress>
-                  <Badge status={progressText(item.progress)}>
-                    {progressText(item.progress)}
-                  </Badge>
+                  <BarProgress number={item.progress} />
+                  <DotBadge status={progressText(item.progress)} />
                 </Item>
               </Link>
             </ListItem>
@@ -73,41 +75,9 @@ export default function SurveyList() {
   );
 }
 
-interface ProgressState {
-  status: string;
-}
-
-interface ProgressNumber {
-  number: number;
-}
-
 const Content = styled.div`
   max-width: 1440px;
   padding: 30px;
-`;
-
-const TitleBox = styled.div`
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  position: sticky;
-  top: 14px;
-  z-index: 20;
-`;
-
-const Title = styled.div`
-  font-size: 30px;
-  font-weight: 700;
-`;
-
-const Button = styled.button`
-  width: 200px;
-  height: 50px;
-  border-radius: 25px;
-  background: ${COLOR.CREAM_ORANGE};
-  font-size: 16px;
-  color: #fff;
-  font-weight: 700;
 `;
 
 const List = styled.div`
@@ -129,30 +99,6 @@ const Item = styled.div`
   padding: 20px;
 `;
 
-const ListIcon = styled.i<ProgressState>`
-  display: inline-block;
-  position: relative;
-  width: 40px;
-  height: 40px;
-  margin-right: 20px;
-  background: url("icon_list.png") no-repeat left center / 100%;
-  &:after {
-    content: "";
-    position: absolute;
-    right: 3px;
-    bottom: 4px;
-    display: inline-block;
-    width: 7px;
-    height: 7px;
-    background: ${(props) => {
-      if (props.status === "Done") return "#ccc";
-      if (props.status === "Not Started") return COLOR.BEIGE;
-      return COLOR.DACK_ORANGE;
-    }};
-    border-radius: 50%;
-  }
-`;
-
 const TextBox = styled.div`
   flex: 4;
   margin-right: 40px;
@@ -164,57 +110,5 @@ const TextBox = styled.div`
     margin-top: 10px;
     font-size: 14px;
     line-height: 20px;
-  }
-`;
-
-const Progress = styled.div<ProgressNumber>`
-  flex: 2;
-  position: relative;
-  width: 250px;
-  height: 10px;
-  margin-right: 40px;
-  background: #eee;
-  font-size: 0;
-  border-radius: 10px;
-  overflow: hidden;
-  &:after {
-    content: "";
-    display: block;
-    position: absolute;
-    left: 0;
-    top: 0;
-    width: ${(props) => `${props.number}%`};
-    height: 10px;
-    background: ${(props) =>
-      props.number === 100 ? "#ccc" : COLOR.DACK_ORANGE};
-  }
-`;
-
-const Badge = styled.div<ProgressState>`
-  flex: 1;
-  position: relative;
-  max-width: 160px;
-  height: 40px;
-  padding: 0 20px 0 40px;
-  border: 1px solid #ccc;
-  border-radius: 20px 20px 0 20px;
-  margin-left: 20px;
-  line-height: 40px;
-  font-size: 14px;
-  font-weight: 700;
-  &:before {
-    content: "";
-    display: inline-block;
-    position: absolute;
-    left: 20px;
-    top: 15px;
-    width: 10px;
-    height: 10px;
-    border-radius: 50%;
-    background: ${(props) => {
-      if (props.status === "Done") return "#ccc";
-      if (props.status === "Not Started") return COLOR.BEIGE;
-      return COLOR.DACK_ORANGE;
-    }};
   }
 `;

--- a/uttils/survey_list/index.ts
+++ b/uttils/survey_list/index.ts
@@ -1,0 +1,9 @@
+import { PROGRESS_STATUS } from "../../constants/survey_list";
+
+export const progressText = (status: number) => {
+  const { DONE, NOT_STARTED, IN_PROGRESS } = PROGRESS_STATUS;
+
+  if (status === 100) return DONE;
+  if (status === 0) return NOT_STARTED;
+  return IN_PROGRESS;
+};


### PR DESCRIPTION
임시로 작업 해 두었던 설문 목록 페이지에서 타이틀, 버튼, 뱃지 등 공통으로 사용 할 수 있는 컴포넌트를 분리 하였습니다.